### PR TITLE
Change module name to score_crates

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-module(name = "score-crates")
+module(name = "score_crates")
 
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_rust", version = "0.61.0")


### PR DESCRIPTION
Following the implicitly established names, this one is now called "score_crates".