### PR TITLE
chore(bazel): make module declarations one line

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,11 +10,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-module(
-    name = "score_crates",
-    version = "0.0.7",
-    compatibility_level = 0,
-)
+module(name = "score_crates")
 
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")


### PR DESCRIPTION
<!-- repo-sync-policy: bazel.module-one-line -->

## Policy

**`bazel.module-one-line`**

Keep the Bazel module declaration compact and consistent.

## Why this repository?

This repository contains policy-managed legacy content in `MODULE.bazel`.

## Changes

- `MODULE.bazel`: replace matching text
  - Do not hardcode the module version in Git; the Bazel Registry derives it dynamically when a Git release of the module is made, and `compatibility_level` is deprecated.

---

This pull request is managed by `repo-sync` and may be updated by a later policy run.  
Please report any issues to [#score-infrastructure](https://sdvworkinggroup.slack.com/archives/C0894QGRZDM).

> [!WARNING]
> The tool producing this PR is in proof-of-concept stage. Review carefully.
